### PR TITLE
Get rid of apt-key as a required executable as it is optional

### DIFF
--- a/appimagebuilder/modules/deploy/apt/venv.py
+++ b/appimagebuilder/modules/deploy/apt/venv.py
@@ -23,7 +23,7 @@ from urllib import request
 from appimagebuilder.utils import shell
 from .package import Package
 
-DEPENDS_ON = ["dpkg-deb", "apt-get", "apt-key", "fakeroot", "apt-cache"]
+DEPENDS_ON = ["dpkg-deb", "apt-get", "fakeroot", "apt-cache"]
 
 
 class Venv:


### PR DESCRIPTION
`apt-key` is now deprecated in debian stable (trixie), which makes appimage-builder unusable on Debian Stable right now without hacks.

However, apt-key is required only if keys need to be retrieved from the `sourceline`. If a key is given with `key_url`, then `apt-key` is never called.

Thus, apt-key should not be considered as a required executable.